### PR TITLE
Faketime fix

### DIFF
--- a/runtests_local.sh
+++ b/runtests_local.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 TIME_BEFORE=0
+FORCED_DATE=no
 HAS_OPTION=no
 BROWSER=firefox
 
@@ -20,6 +21,7 @@ do
     case $OPTION in
     s)
         TIME_BEFORE=$OPTARG
+        FORCED_DATE=yes
         ;;
     b)
         BROWSER=$OPTARG
@@ -53,7 +55,7 @@ export COUNT=$COUNT
 
 echo "[INFO] start tests:"
 echo " browser: $BROWSER"
-echo " time shift: $TIME_BEFORE"
+echo " time shift: -$TIME_BEFORE"
 echo " count: $COUNT"
 
 set -o errexit
@@ -90,11 +92,25 @@ fi
 
 sleep 1
 
+if [[ $FORCED_DATE == yes ]]
+then
+    if [[ $(uname) == Darwin ]]
+    then
+        export DYLD_INSERT_LIBRARIES=/usr/local/lib/faketime/libfaketime.1.dylib
+    else
+        export LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1
+    fi
+    export DYLD_FORCE_FLAT_NAMESPACE=1
+    export FAKETIME="-${TIME_BEFORE}s"
+fi
+
 if [[ -z "$DISPLAY" ]];
 then
-    BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -l -a /usr/local/bin/faketime -f -${TIME_BEFORE}s python $TESTFIELDDIR/runtests.py $@
+    echo BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -l -a python $TESTFIELDDIR/runtests.py $@
+    BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -l -a python $TESTFIELDDIR/runtests.py $@
 else
-    BROWSER="$BROWSER" /usr/local/bin/faketime -f -${TIME_BEFORE}s python $TESTFIELDDIR/runtests.py $@
+    echo BROWSER="$BROWSER" python $TESTFIELDDIR/runtests.py $@
+    BROWSER="$BROWSER" python $TESTFIELDDIR/runtests.py $@
 fi
 
 RETVAR=$?

--- a/runtests_local.sh
+++ b/runtests_local.sh
@@ -90,8 +90,6 @@ if [ $BROWSER = "firefox" ]; then
     fi
 fi
 
-sleep 1
-
 if [[ $FORCED_DATE == yes ]]
 then
     if [[ $(uname) == Darwin ]]

--- a/runtests_server.sh
+++ b/runtests_server.sh
@@ -160,7 +160,7 @@ else
     python restore.py --reset-versions $ENVNAME
 fi
 
-./scripts/upgrade_unifield.sh -d $SERVER_TMPDIR $NAME $ENVNAME
+./scripts/upgrade_unifield.sh -s $MINUS_IN_SECOND -d $SERVER_TMPDIR $NAME $ENVNAME
 
 ./scripts/start_unifield.sh -s $MINUS_IN_SECOND -d $SERVER_TMPDIR run $NAME
 

--- a/scripts/create_db.sh
+++ b/scripts/create_db.sh
@@ -5,9 +5,10 @@ set -o pipefail
 
 DBPATH=/tmp
 DBDIR=
-FORCED_DATE=no
 DBPORT=5432
 CREDENTIALS=testing
+FORCED_DATE=no
+TIME_BEFORE=0
 
 function usage()
 {
@@ -54,6 +55,7 @@ echo " dir: $DBDIR"
 echo " port: $DBPORT"
 echo " username: $CREDENTIALS"
 echo " password: $CREDENTIALS"
+echo " time shift: -$TIME_BEFORE"
 
 POS_PARAM=(${@:$OPTIND})
 NAME_KILL=${POS_PARAM[0]}
@@ -107,6 +109,13 @@ DBADDR=localhost
 
 mkdir $DATADIR $RUNDIR
 
+# we have to change the date before the initdb otherwise PostgreSQL doesn't take the
+#   new date into account.
+if [[ $FORCED_DATE == yes ]]
+then
+    source scripts/setup_faketime.sh ${TIME_BEFORE}
+fi
+
 $DBDIR/initdb --username=$USER $DATADIR
 
 echo "port = $DBPORT" >> $DATADIR/postgresql.conf
@@ -116,14 +125,7 @@ then
     echo "unix_socket_directory = '$RUNDIR'" >> $DATADIR/postgresql.conf
 fi
 
-START_FAKETIME=
-if [[ $FORCED_DATE == yes ]]
-then
-    START_FAKETIME="faketime -f -${TIME_BEFORE}s"
-fi
-
-sleep 1
-tmux new -d -s PostGre_$NAME_KILL "${START_FAKETIME} $DBDIR/postgres -D $DATADIR"
+tmux new -d -s PostGre_$NAME_KILL "$DBDIR/postgres -D $DATADIR"
 
 #TODO: Fix that... we should wait until psql can connect
 for i in $(seq 1 10);

--- a/scripts/setup_faketime.sh
+++ b/scripts/setup_faketime.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+#set -o errexit
+#set -o pipefail
+
+
+
+
+TIME_BEFORE=
+FORCED_DATE=no
+
+if [[ $# -le 1 ]]
+then
+    unset DYLD_INSERT_LIBRARIES
+    unset LD_PRELOAD
+
+    unset FAKETIME
+    unset DYLD_FORCE_FLAT_NAMESPACE
+
+    if [[ $# == 1 ]];
+    then
+        if [[ $(uname) == Darwin ]]
+        then
+            export DYLD_INSERT_LIBRARIES=/usr/local/lib/faketime/libfaketime.1.dylib
+        else
+            export LD_PRELOAD=/usr/local/lib/faketime/libfaketime.so.1
+        fi
+        export DYLD_FORCE_FLAT_NAMESPACE=1
+        export FAKETIME=-${1}s
+
+        # we have to ensure to export the new environment variables
+        #  if we create a new tmux session.
+        tmux set-option -ga update-environment ' FAKETIME DYLD_FORCE_FLAT_NAMESPACE LD_PRELOAD DYLD_INSERT_LIBRARIES' || true
+    fi
+
+else
+    echo $0 [time]
+    echo "  time: number of seconds to shift (default: no)"
+fi
+
+if [[ ${FAKETIME} ]]
+then
+    echo Shift: -${1}s
+else
+    echo Shift: no
+fi
+echo Current date: $(date)
+

--- a/scripts/start_unifield.sh
+++ b/scripts/start_unifield.sh
@@ -27,6 +27,7 @@ function usage()
 BDIR=/tmp
 CONFIG_FILE="$(pwd)/config.sh"
 TIME_BEFORE=
+FORCED_DATE=no
 
 while getopts "s:d:h" OPTION
 do
@@ -36,6 +37,7 @@ do
         exit 1
         ;;
     s)
+        FORCED_DATE=yes
         TIME_BEFORE=$OPTARG
         ;;
     d)
@@ -55,11 +57,9 @@ POS_PARAM=(${@:$OPTIND})
 ACTION=${POS_PARAM[0]}
 NAME=${POS_PARAM[1]}
 
-
-START_FAKETIME=
-if [[ $TIME_BEFORE ]]
+if [[ $FORCED_DATE == yes ]]
 then
-    START_FAKETIME="faketime -f -${TIME_BEFORE}s"
+    source scripts/setup_faketime.sh ${TIME_BEFORE}
 fi
 
 if ! which unbuffer >&2 > /dev/null;
@@ -293,8 +293,8 @@ case $ACTION in
 
     run)
 
-        echo "Run WEB: $START_FAKETIME python $WEBDIR/openerp-web.py -c $CFG_WEB"
-        echo "RUN SERVER: $START_FAKETIME python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER"
+        echo "Run WEB: python $WEBDIR/openerp-web.py -c $CFG_WEB"
+        echo "RUN SERVER: python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER"
 
         # we print the commands to launch the components in a separate window in order to debug.
         #  We'll launch them later in a tmux
@@ -303,13 +303,13 @@ case $ACTION in
             sleep 1;
 
             tmux new-window -n web \"
-            $START_FAKETIME $UNBUFFER_CMD python $WEBDIR/openerp-web.py -c $CFG_WEB > $WEBDIR/web.logs 2>&1 & PID="'\$!'" ;
+            $UNBUFFER_CMD python $WEBDIR/openerp-web.py -c $CFG_WEB > $WEBDIR/web.logs 2>&1 & PID="'\$!'" ;
             echo \\\$PID > $PID_WEB_FILE;
             wait \\\$PID;
             \";
             sleep 1;
 
-            $START_FAKETIME $UNBUFFER_CMD python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER > $SERVERDIR/server.logs 2>&1 & PID="'$!'" ;
+            $UNBUFFER_CMD python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER > $SERVERDIR/server.logs 2>&1 & PID="'$!'" ;
             echo \$PID > $PID_SERVER_FILE;
             wait \$PID;
             \""
@@ -328,7 +328,7 @@ case $ACTION in
             REAL_NAME=${DBPREFIX}_${REAL_NAME}
         fi
 
-        $START_FAKETIME python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER -u base --stop-after-init -d $REAL_NAME
+        python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER -u base --stop-after-init -d $REAL_NAME
 
         ;;
     *)

--- a/scripts/start_unifield.sh
+++ b/scripts/start_unifield.sh
@@ -300,14 +300,12 @@ case $ACTION in
         #  We'll launch them later in a tmux
         SESSION_NAME=unifield_$NAME
         tmux new -d -s $SESSION_NAME -n server "
-            sleep 1;
 
             tmux new-window -n web \"
             $UNBUFFER_CMD python $WEBDIR/openerp-web.py -c $CFG_WEB > $WEBDIR/web.logs 2>&1 & PID="'\$!'" ;
             echo \\\$PID > $PID_WEB_FILE;
             wait \\\$PID;
             \";
-            sleep 1;
 
             $UNBUFFER_CMD python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER > $SERVERDIR/server.logs 2>&1 & PID="'$!'" ;
             echo \$PID > $PID_SERVER_FILE;

--- a/scripts/start_unifield.sh
+++ b/scripts/start_unifield.sh
@@ -10,7 +10,7 @@ function usage()
     echo $0 [-h] [-d dir] version name
     echo $0 [-h] [-d dir] logs name
     echo "  -h: help"
-    echo "  -s: number of seconds to shift"
+    echo "  -s: number of seconds to shift (default: no)"
     echo "  -c: configuration file (default \$(pwd)/config.sh). Values looked up in this file are:"
     echo "       XMLRPCS_PORT:"
     echo "       XMLRPC_PORT:"
@@ -328,7 +328,7 @@ case $ACTION in
             REAL_NAME=${DBPREFIX}_${REAL_NAME}
         fi
 
-        python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER -u base --stop-after-init -d $REAL_NAME
+        $START_FAKETIME python $SERVERDIR/bin/openerp-server.py $PARAM_UNIFIELD_SERVER -u base --stop-after-init -d $REAL_NAME
 
         ;;
     *)

--- a/steps.py
+++ b/steps.py
@@ -109,6 +109,11 @@ def connect_to_db():
     base_dir = os.path.dirname(__file__)
     file_path = os.path.join(base_dir, FILE_DIR)
 
+    # we have to clean the environment variables, otherwise Firefox crash with the following
+    #  error message: SQLite Version Error
+    if 'DYLD_FORCE_FLAT_NAMESPACE' in os.environ:
+        del os.environ['DYLD_FORCE_FLAT_NAMESPACE']
+
     if 'BROWSER' not in os.environ or os.environ['BROWSER'] == "firefox":
         # we are going to download all the files in the file directory
         profile = webdriver.FirefoxProfile()


### PR DESCRIPTION
These commits:
- Fix a bug discussed https://github.com/wolfcw/libfaketime/issues/96. Faketime sometimes crashes when we launch a process with the wrapper (instead of using only the library). The error message is:

> sem_open: File exists

- Invert a commit supposed to fix the bug discussed above
- Activate faketime when we upgrade the databases. This is important since the objects modified "in the future" are sent at each synchronisation. Such case "almost" never happen in production. However, it happens if we are not consistent when we use libfaketime.
