### PR TITLE
No tcp / sync server name

### DIFF
--- a/runtests_local.sh
+++ b/runtests_local.sh
@@ -104,8 +104,8 @@ fi
 
 if [[ -z "$DISPLAY" ]];
 then
-    echo BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -l -a python $TESTFIELDDIR/runtests.py $@
-    BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -l -a python $TESTFIELDDIR/runtests.py $@
+    echo BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -a python $TESTFIELDDIR/runtests.py $@
+    BROWSER="$BROWSER" xvfb-run -s '-screen 1 1024x768x16' -a python $TESTFIELDDIR/runtests.py $@
 else
     echo BROWSER="$BROWSER" python $TESTFIELDDIR/runtests.py $@
     BROWSER="$BROWSER" python $TESTFIELDDIR/runtests.py $@

--- a/scripts/create_db.sh
+++ b/scripts/create_db.sh
@@ -12,7 +12,7 @@ TIME_BEFORE=0
 
 function usage()
 {
-    echo $0 [-h] -P execpath [-D dbpath] [-d seconds] [-p port] [-c credentials] name
+    echo $0 [-h] -P execpath [-D dbpath] [-s seconds] [-p port] [-c credentials] name
     echo "  -h: help"
     echo "  -P: path to PostgreSQL"
     echo "  -D: set the DB path var/run in a specific directory (default: /tmp)"
@@ -108,12 +108,13 @@ RUNDIR=$DBPATH/run-$NAME_KILL
 DBADDR=localhost
 
 mkdir $DATADIR $RUNDIR
-
+FAKED_COMMAND=''
 # we have to change the date before the initdb otherwise PostgreSQL doesn't take the
 #   new date into account.
 if [[ $FORCED_DATE == yes ]]
 then
     source scripts/setup_faketime.sh ${TIME_BEFORE}
+    FAKED_COMMAND="FAKETIME=$FAKETIME LD_PRELOAD=$LD_PRELOAD"
 fi
 
 $DBDIR/initdb --username=$USER $DATADIR
@@ -125,7 +126,7 @@ then
     echo "unix_socket_directory = '$RUNDIR'" >> $DATADIR/postgresql.conf
 fi
 
-tmux new -d -s PostGre_$NAME_KILL "$DBDIR/postgres -D $DATADIR"
+tmux new -d -s PostGre_$NAME_KILL "$FAKED_COMMAND $DBDIR/postgres -D $DATADIR"
 
 #TODO: Fix that... we should wait until psql can connect
 for i in $(seq 1 10);

--- a/scripts/setup_faketime.sh
+++ b/scripts/setup_faketime.sh
@@ -30,7 +30,8 @@ then
 
         # we have to ensure to export the new environment variables
         #  if we create a new tmux session.
-        tmux set-option -ga update-environment ' FAKETIME DYLD_FORCE_FLAT_NAMESPACE LD_PRELOAD DYLD_INSERT_LIBRARIES' || true
+        # does not work !
+        # tmux set-option -ga update-environment ' FAKETIME DYLD_FORCE_FLAT_NAMESPACE LD_PRELOAD DYLD_INSERT_LIBRARIES' || true
     fi
 
 else

--- a/scripts/start_unifield.sh
+++ b/scripts/start_unifield.sh
@@ -56,17 +56,18 @@ POS_PARAM=(${@:$OPTIND})
 
 ACTION=${POS_PARAM[0]}
 NAME=${POS_PARAM[1]}
-
+FAKED_COMMAND=""
 if [[ $FORCED_DATE == yes ]]
 then
     source scripts/setup_faketime.sh ${TIME_BEFORE}
+    FAKED_COMMAND="FAKETIME=$FAKETIME LD_PRELOAD=$LD_PRELOAD"
 fi
 
 if ! which unbuffer >&2 > /dev/null;
 then
-    UNBUFFER_CMD=
+    UNBUFFER_CMD=$FAKED_COMMAND
 else
-    UNBUFFER_CMD="unbuffer"
+    UNBUFFER_CMD="unbuffer $FAKED_COMMAND"
 fi
 
 SERVERDIR=$BDIR/server_$NAME


### PR DESCRIPTION
 - X client should not open a tcp port
 - when restoring instances, update database name in Connection Manager according to the name of the sync server dump.